### PR TITLE
Custom Quay Repository

### DIFF
--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -11,7 +11,7 @@ on:
       quay_img_exp:
         required: true
         type: string
-      quay_custom_repo:
+      quay_custom_namespace:
         required: false
         type: string
       github_username:
@@ -25,7 +25,7 @@ env:
   IMAGE_NAME: ${{ inputs.image_name }}
   IMAGE_TAG: ${{ inputs.image_tag }}
   QUAY_IMG_EXP: ${{ inputs.quay_img_exp }}
-  QUAY_CUSTOM_REPO: ${{ inputs.quay_custom_repo }}
+  QUAY_CUSTOM_NAMESPACE: ${{ inputs.quay_custom_namespace }}
   GITHUB_USERNAME: ${{ inputs.github_username }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_NAMESPACE: ${{ inputs.github_namespace }}

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -25,6 +25,7 @@ env:
   IMAGE_NAME: ${{ inputs.image_name }}
   IMAGE_TAG: ${{ inputs.image_tag }}
   QUAY_IMG_EXP: ${{ inputs.quay_img_exp }}
+  QUAY_CUSTOM_REPO: ${{ inputs.quay_custom_repo }}
   GITHUB_USERNAME: ${{ inputs.github_username }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_NAMESPACE: ${{ inputs.github_namespace }}

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -25,11 +25,11 @@ env:
   IMAGE_NAME: ${{ inputs.image_name }}
   IMAGE_TAG: ${{ inputs.image_tag }}
   QUAY_IMG_EXP: ${{ inputs.quay_img_exp }}
-  QUAY_CUSTOM_NAMESPACE: ${{ inputs.quay_custom_namespace }}
   GITHUB_USERNAME: ${{ inputs.github_username }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_NAMESPACE: ${{ inputs.github_namespace }}
   QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
+  QUAY_CUSTOM_NAMESPACE: ${{ inputs.quay_custom_namespace }}
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 jobs:

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -50,6 +50,6 @@ jobs:
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: Carpenter build
-        uses: jdowni000/arcaflow-plugin-image-builder@repository
+        uses: arcalot/arcaflow-plugin-image-builder@main
         with:
           args: build --build --push

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -49,6 +49,6 @@ jobs:
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: Carpenter build
-        uses: jdownie/arcaflow-plugin-image-builder@repository
+        uses: jdowni000/arcaflow-plugin-image-builder@repository
         with:
           args: build --build --push

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -49,6 +49,6 @@ jobs:
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: Carpenter build
-        uses: arcalot/arcaflow-plugin-image-builder@main
+        uses: jdownie/arcaflow-plugin-image-builder@repository
         with:
           args: build --build --push

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -11,6 +11,9 @@ on:
       quay_img_exp:
         required: true
         type: string
+      quay_custom_repo:
+        required: false
+        type: string
       github_username:
         required: false
         type: string


### PR DESCRIPTION
## Changes introduced with this PR

With the merger of [PR #38](https://github.com/arcalot/arcaflow-plugin-image-builder/pull/38) in carpenter, the
reusable workflow needs to be set up to accept input for the custom namespace to pass to carpenter.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).