### PR TITLE
allow QUAY_ secrets to be passed to the reusable workflow

### DIFF
--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -20,6 +20,13 @@ on:
       github_namespace:
         required: false
         type: string    
+    secrets:
+      QUAY_NAMESPACE:
+        required: false
+      QUAY_USERNAME:
+        required: false
+      QUAY_PASSWORD:
+        required: false
 
 env:
   IMAGE_NAME: ${{ inputs.image_name }}


### PR DESCRIPTION
## Changes introduced with this PR

Based on the [documentation](https://docs.github.com/en/actions/using-workflows/reusing-workflows) and some testing, it looks like we need to explicitly define and allow the named secrets to be passed from a calling workflow.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).