### PR TITLE
Go lint and test

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -1,0 +1,65 @@
+# Reusable workflow for the repositories of the Arcalot organization.
+# This workflow provides linting and testing of Go sources and produces
+# a coverage report.  (It is only run when invoked by another workflow.)
+on:
+  workflow_call:
+env:
+  go_version: ${{ vars.ARCALOT_GO_VERSION }}
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.55.2
+          args: --timeout=3m
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Set up gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-test-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-test-
+      - name: Run go test
+        run: |
+          set -euo pipefail
+          go generate
+          go test -coverprofile /tmp/coverage.out -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+          echo "# Code coverage summary" > /tmp/coverage.md
+          echo "|File|Type|Coverage|" >> /tmp/coverage.md
+          echo "|----|----|--------|" >> /tmp/coverage.md
+          go tool cover -func /tmp/coverage.out | sed -E -e 's/\s+/|/g' -e 's/^(.*)$/|\1|/' >> /tmp/coverage.md
+          cat /tmp/coverage.md >> $GITHUB_STEP_SUMMARY
+          echo "::group::Code coverage summary"
+          go tool cover -func /tmp/coverage.out
+          echo "::endgroup::"
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            /tmp/gotest.log
+            /tmp/coverage.out
+            /tmp/coverage.md
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # arcaflow-reusable-workflows
-Repository for storing reusable workflows to be utilized for the arcaflow community
+Repository for storing GitHub reusable workflows to be utilized for the arcaflow community.


### PR DESCRIPTION
## Changes introduced with this PR

This change adds a common "GitHub reusable workflow" for use by the various Arcalot repositories for linting and testing Go code.

This will provide a centralized procedure which can be more easily maintained, and it can be updated in one place when GitHub actions and other dependencies are upgraded. This will cut down on the noise from the Renovate bot and will hopefully make it easy to manage these upgrades. It will also provide uniform treatment for the various repositories.

> [!NOTE]
> This workflow depends on a global variable, `ARCALOT_GO_VERSION`, to determine the Go version.  Ideally, this variable should be defined in the `arcalot` organization, so that all the uses of this workflow will use the same version.  (Individual repositories _can_ override the value (and individual workflows can, as well), but we should resist this.)  When this PR is merged, someone with suitable access to the Arcalot organization will need to create the variable.

This PR also tweaks the text in the `README.md`, to try to make it clear that _this_ repository is for **GitHub** _workflows_, not **Arcaflow** workflows.... 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).