### PR TITLE
Add workflows for building the Go release and the Python wheel

### DIFF
--- a/.github/workflows/build_python_wheel.yaml
+++ b/.github/workflows/build_python_wheel.yaml
@@ -1,0 +1,66 @@
+# Reusable workflow for the repositories of the Arcalot organization.
+# This workflow builds a Python "wheel" for distributing the package.
+# It requires the PYPI_TOKEN secret.
+# (It is only run when invoked by another workflow.)
+on:
+  workflow_call:
+    secrets:
+      PYPI_TOKEN:
+        required: true
+env:
+  python_version: ${{ vars.ARCALOT_PYTHON_VERSION }}
+jobs:
+  build_python_wheel:
+    name: build python wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: version format check
+        if: startsWith(github.event.ref, 'refs/tags/')
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          if [[ ${VERSION//[[:blank:]]/} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+([-+][[:alnum:]]+)?$ ]]
+          then echo "[INF] version format accepted"
+          else echo "[ERR] wrong version format: $VERSION" ; exit 1
+          fi
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: python/artifacts
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.python_version }}
+          architecture: 'x64'
+      - name: Grab the License file
+        run: |
+          cp LICENSE python/
+      - name: Fetch python dependencies
+        working-directory: python
+        shell: bash
+        run: |
+          make setup
+      - name: Bump version
+        if: startsWith(github.event.ref, 'refs/tags/')
+        working-directory: python
+        env:
+          VERSION: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          sed -ri "s/^(.+version=')(.+)('.*)$/\1${VERSION/v/}\3/" setup.py
+      - name: Build python wheel
+        working-directory: python
+        run: |
+          make all
+      - name: Push to pypi
+        if: startsWith(github.event.ref, 'refs/tags/')
+        working-directory: python
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/*

--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -1,0 +1,65 @@
+# Reusable workflow for the repositories of the Arcalot organization.
+# This workflow provides linting and testing of Go sources and produces
+# a coverage report.  (It is only run when invoked by another workflow.)
+on:
+  workflow_call:
+env:
+  go_version: ${{ vars.ARCALOT_GO_VERSION }}
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.55.2
+          args: --timeout=3m
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Set up gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-test-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-test-
+      - name: Run go test
+        run: |
+          set -euo pipefail
+          go generate
+          go test -coverprofile /tmp/coverage.out -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+          echo "# Code coverage summary" > /tmp/coverage.md
+          echo "|File|Type|Coverage|" >> /tmp/coverage.md
+          echo "|----|----|--------|" >> /tmp/coverage.md
+          go tool cover -func /tmp/coverage.out | sed -E -e 's/\s+/|/g' -e 's/^(.*)$/|\1|/' >> /tmp/coverage.md
+          cat /tmp/coverage.md >> $GITHUB_STEP_SUMMARY
+          echo "::group::Code coverage summary"
+          go tool cover -func /tmp/coverage.out
+          echo "::endgroup::"
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            /tmp/gotest.log
+            /tmp/coverage.out
+            /tmp/coverage.md
+          if-no-files-found: error

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -1,0 +1,45 @@
+# Reusable workflow for the repositories of the Arcalot organization.
+# This workflow builds a Go release.
+#
+# It builds either a "release" or a "snapshot" (depending on the value of the
+# `for_release` input, which should be set to true or false, respectively) and
+# uploads the resulting binary artifacts.
+#
+# (It is only run when invoked by another workflow.)
+on:
+  workflow_call:
+    inputs:
+      for_release:
+        required: true
+        type: boolean
+env:
+  go_version: ${{ vars.ARCALOT_GO_VERSION }}
+jobs:
+  build:
+    name: build ${{ inputs.for_release && 'release' || 'snapshot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.go_version }}
+      - name: Build ${{ inputs.for_release && 'release' || 'snapshot' }}
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          GITHUB_TOKEN: ${{ inputs.for_release && secrets.GITHUB_TOKEN || '' }}
+          GOPROXY: direct
+          GOSUMDB: off
+          ARGS: ${{ inputs.for_release && 'release --clean' || 'build --snapshot' }}
+        with:
+          distribution: goreleaser
+          version: latest
+          args: ${{ env.ARGS }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: dist

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -20,7 +20,7 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
         run: |
-          if [[ ${VERSION//[[:blank:]]/} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+([-+][[:alnum:]]+)?$ ]]
+          if [[ ${VERSION//[[:blank:]]/} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-[[:alnum:].-]+)?(\+[[:alnum:].-]+)?$ ]]
           then echo "[INF] version format accepted"
           else echo "[ERR] wrong version format: $VERSION" ; exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # arcaflow-reusable-workflows
-Repository for storing reusable workflows to be utilized for the arcaflow community
+Repository for storing GitHub reusable workflows to be utilized for the arcaflow community.


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds reusable workflows for building the Go release and the Python wheel.  They were extracted from the `engine` build and the `docsgen` build and harmonized.  Also, this change fixes a bug in the version string validation and it streamlines a bit of awkward shell code.

Note:  I tested these using my fork, and they work for the `main` branch, but I was unable to get the `go_release` to work for tagged commits (and the Engine build won't run the `python_build_wheel` workflow if the `go_release` workflow fails).  I'm assuming that the issue is something in my environment (e.g., trying to run outside the `arcalot` organization); once this PR is merged, then I hope to be able to test better (and hopefully it will all "just work").  Currently, nothing depends on these workflows, so having them merged while broken won't have any adverse effects.

Also note:  at the time of this writing, this PR consists of a single commit, but, for some reason, GitHub is displaying three.  I don't know how it seems to be out of sync with the base repository....

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).