### PR TITLE
Pass Go/Python version as an explicit input

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -3,8 +3,10 @@
 # a coverage report.  (It is only run when invoked by another workflow.)
 on:
   workflow_call:
-env:
-  go_version: ${{ vars.ARCALOT_GO_VERSION }}
+    inputs:
+      go_version:
+        required: true
+        type: string
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -15,7 +17,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ inputs.go_version }}
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
@@ -30,7 +32,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ inputs.go_version }}
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
       - uses: actions/cache@v4

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -12,8 +12,9 @@ on:
       for_release:
         required: true
         type: boolean
-env:
-  go_version: ${{ vars.ARCALOT_GO_VERSION }}
+      go_version:
+        required: true
+        type: string
 jobs:
   build:
     name: build ${{ inputs.for_release && 'release' || 'snapshot' }}
@@ -26,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.go_version }}
+          go-version: ${{ inputs.go_version }}
       - name: Build ${{ inputs.for_release && 'release' || 'snapshot' }}
         uses: goreleaser/goreleaser-action@v5
         env:

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -4,11 +4,13 @@
 # (It is only run when invoked by another workflow.)
 on:
   workflow_call:
+    inputs:
+      python_version:
+        required: true
+        type: string
     secrets:
       PYPI_TOKEN:
         required: true
-env:
-  python_version: ${{ vars.ARCALOT_PYTHON_VERSION }}
 jobs:
   build_python_wheel:
     name: build python wheel
@@ -34,7 +36,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.python_version }}
+          python-version: ${{ inputs.python_version }}
           architecture: 'x64'
       - name: Grab the License file
         run: |


### PR DESCRIPTION
## Changes introduced with this PR

This PR modifies `go_lint_and_test.yaml`, `go_release.yaml`, and `python_release.yaml` to access the required version of Go or Python from the workflow inputs instead of trying to obtain it from a global variable.  Access to variables has proved unreliable when executing workflows from PRs from forks.  Also, making the values be explicit inputs instead better encapsulates and properly decouples the reusable workflows from the calling workflows and organizations.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).