### PR TITLE
Add Quay login to the Go release workflow

### DIFF
--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -15,6 +15,13 @@ on:
       go_version:
         required: true
         type: string
+    secrets:
+      QUAY_USERNAME:
+        required: false
+      QUAY_PASSWORD:
+        required: false
+env:
+  do_login: ${{ secrets.QUAY_USERNAME != '' }}
 jobs:
   build:
     name: build ${{ inputs.for_release && 'release' || 'snapshot' }}
@@ -28,6 +35,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go_version }}
+      - name: Login to Quay.io
+        if: do_login && startsWith(github.event.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Build ${{ inputs.for_release && 'release' || 'snapshot' }}
         uses: goreleaser/goreleaser-action@v5
         env:


### PR DESCRIPTION
## Changes introduced with this PR

The refactoring which resulted in the `go_release` reusable workflow works for `arcaflow-docsgen` but not for `arcaflow-engine`, because the former is not configured to build a container while the latter is.  Once the container is built, it is pushed to an external registry, for which we need credentials.  This PR adds a step which performs a `docker login` to set that up, if the necessary secrets are provided in the call to the reusable workflow.

(Note that the `secrets` context is not available for use with the `jobs.<job-id>.if` keyword, so we set up a boolean value in a job `env` variable and test that instead.)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).