### PR TITLE
Add context specifier to conditional in Go release workflow

### DIFF
--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: ${{ inputs.go_version }}
       - name: Login to Quay.io
-        if: do_login && startsWith(github.event.ref, 'refs/tags/')
+        if: env.do_login && startsWith(github.event.ref, 'refs/tags/')
         uses: docker/login-action@v3
         with:
           registry: quay.io


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds a missing context specifier to a conditional in Go release workflow.

(Unfortunately, it is difficult to test reusable workflows without merging them first, so we get to have PRs like this one....  Hopefully, it will work this time.)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).