### PR TITLE
Add reusable workflow for running `go generate`

### DIFF
--- a/.github/scripts/gogenerate.sh
+++ b/.github/scripts/gogenerate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+export NOLINT=1
+go generate >/tmp/gogenerate.output 2>/tmp/gogenerate.output
+if [ $? -ne 0 ]; then
+  echo -e "::group::\e[0;31m❌ Go generate failed.\e[0m"
+  cat /tmp/gogenerate.output
+  echo "::endgroup::"
+  exit 1
+fi
+
+echo -e "::group::\e[0;32m✅ Go generate succeeded.\e[0m"
+cat /tmp/gogenerate.output
+echo "::endgroup::"
+
+git diff >/tmp/gogenerate.diff
+if [ "$(cat /tmp/gogenerate.diff | wc -l)" -ne 0 ]; then
+  echo -e "::group::\e[0;31m❌ Git changes after go generate.\e[0m"
+  echo "The following is the diff of files:"
+  cat /tmp/gogenerate.diff
+  echo "::endgroup::"
+  echo -e "\e[0;31m⚙ Please run go generate before pushing your changes.\e[0m"
+  exit 1
+fi
+
+echo -e "::group::\e[0;32m✅ No changes after go generate.\e[0m"
+echo "::endgroup::"

--- a/.github/scripts/gogenerate.sh
+++ b/.github/scripts/gogenerate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export NOLINT=1
-go generate >/tmp/gogenerate.output 2>/tmp/gogenerate.output
+go generate >/tmp/gogenerate.output 2>&1
 if [ $? -ne 0 ]; then
   echo -e "::group::\e[0;31m❌ Go generate failed.\e[0m"
   cat /tmp/gogenerate.output

--- a/.github/workflows/go_generate.yaml
+++ b/.github/workflows/go_generate.yaml
@@ -1,0 +1,29 @@
+# Reusable workflow for the repositories of the Arcalot organization.
+# This workflow runs a wrapper script for the Go `generate` command.
+# (It is only run when invoked by another workflow.)
+on:
+  workflow_call:
+    inputs:
+      go_version:
+        required: true
+        type: string
+jobs:
+  generate:
+    name: go generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ inputs.go_version }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-test-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-generate-
+      - name: Run go generate
+        run: ./.github/scripts/gogenerate.sh


### PR DESCRIPTION
## Changes introduced with this PR

This PR provides the common code extracted from the `arcaflow-plugin-sdk-go` and `arcaflow-engine` repositories for running the `go generate` command:  a common, reusable workflow and the wrapper script which it invokes.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).