### PR TITLE
Rework common Go workflows

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -42,20 +42,23 @@ jobs:
             ~/.cache/go-build
           key: go-test-${{ hashFiles('**/go.sum') }}
           restore-keys: go-test-
+      - name: Set up limgo
+        uses: GoTestTools/limgo-action@v1.0.2
+        with:
+          version: "v1.0.0"
+          install-only: true
+      - name: Setup mocks
+        run: |
+          go install go.uber.org/mock/mockgen@v0.4.0
+          go generate ./...
       - name: Run go test
         run: |
           set -euo pipefail
-          go generate
           go test -coverprofile /tmp/coverage.out -json -v ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
-          echo "# Code coverage summary" > /tmp/coverage.md
-          echo "|File|Type|Coverage|" >> /tmp/coverage.md
-          echo "|----|----|--------|" >> /tmp/coverage.md
-          go tool cover -func /tmp/coverage.out | sed -E -e 's/\s+/|/g' -e 's/^(.*)$/|\1|/' >> /tmp/coverage.md
+          cat .limgo.json
+          limgo -coverfile=/tmp/coverage.out -config=.limgo.json -outfmt=md -outfile=/tmp/coverage.md
           cat /tmp/coverage.md >> $GITHUB_STEP_SUMMARY
-          echo "::group::Code coverage summary"
-          go tool cover -func /tmp/coverage.out
-          echo "::endgroup::"
-      - name: Upload test log
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -55,7 +55,7 @@ jobs:
           ARGS: ${{ inputs.for_release && 'release --clean' || 'build --snapshot' }}
         with:
           distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: ${{ env.ARGS }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -15,13 +15,17 @@ on:
       go_version:
         required: true
         type: string
-    secrets:
-      QUAY_USERNAME:
+      registry:
         required: false
-      QUAY_PASSWORD:
+        type: string
+        default: quay.io
+    secrets:
+      REGISTRY_USERNAME:
+        required: false
+      REGISTRY_PASSWORD:
         required: false
 env:
-  do_login: ${{ secrets.QUAY_USERNAME != '' }}
+  do_login: ${{ secrets.REGISTRY_USERNAME != '' }}
 jobs:
   build:
     name: build ${{ inputs.for_release && 'release' || 'snapshot' }}
@@ -35,15 +39,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ inputs.go_version }}
-      - name: Login to Quay.io
+      - name: Login to the ${{ inputs.registry }} container registry
         if: env.do_login && startsWith(github.event.ref, 'refs/tags/')
         uses: docker/login-action@v3
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Build ${{ inputs.for_release && 'release' || 'snapshot' }}
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ inputs.for_release && secrets.GITHUB_TOKEN || '' }}
           GOPROXY: direct


### PR DESCRIPTION
## Changes introduced with this PR

- `lint_and_test`
  - Use limgo to handle coverage output and monitoring
  - Add support for mocks
- `release`
  - Add parameter for container registry
  - Rename username/password inputs to make generic
  - Update goreleaser GHA to v6
  - in-line the password-existence check

(Tested by https://github.com/arcalot/arcaflow-container-toolkit/pull/129 and https://github.com/arcalot/arcaflow-engine/pull/194.)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).