### PR TITLE
Fix `go generate` command for Go 1.22

### DIFF
--- a/.github/workflows/go_generate.yaml
+++ b/.github/workflows/go_generate.yaml
@@ -36,6 +36,7 @@ jobs:
           else msg="32m✅ Go generate succeeded"
           fi
           echo -e "::group::\e[0;${msg}.\e[0m"
+          cat /tmp/gogenerate.output >> $GITHUB_STEP_SUMMARY
           cat /tmp/gogenerate.output
           echo "::endgroup::"
           if [[ $fail -ne 0 ]]; then exit 1; fi

--- a/.github/workflows/go_generate.yaml
+++ b/.github/workflows/go_generate.yaml
@@ -29,14 +29,15 @@ jobs:
         env:
           NOLINT: 1
         run: |
+          set +e
           go generate ./... >/tmp/gogenerate.output 2>&1
           fail=$?
+          set -e
           if [[ $fail -ne 0 ]]
           then msg="31m❌ Go generate failed"
           else msg="32m✅ Go generate succeeded"
           fi
           echo -e "::group::\e[0;${msg}.\e[0m"
-          cat /tmp/gogenerate.output >> $GITHUB_STEP_SUMMARY
           cat /tmp/gogenerate.output
           echo "::endgroup::"
           if [[ $fail -ne 0 ]]; then exit 1; fi

--- a/.github/workflows/go_generate.yaml
+++ b/.github/workflows/go_generate.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           NOLINT: 1
         run: |
-          go generate >/tmp/gogenerate.output 2>&1
+          go generate ./... >/tmp/gogenerate.output 2>&1
           fail=$?
           if [[ $fail -ne 0 ]]
           then msg="31m❌ Go generate failed"


### PR DESCRIPTION
## Changes introduced with this PR

In Go version 1.22, the `go generate` command now returns an error status if no package or file path is specified on the command line.  This change adds the package spec `./...`.

In the course of diagnosing this problem, it became evident that the script's error handling was being defeated by the shell's settings, so this change also includes a tweak for that.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).