### PR TITLE
Update golangci-lint to version 1.63.4

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.63.4
           args: --timeout=3m
   test:
     name: go test


### PR DESCRIPTION
## Changes introduced with this PR

With the update to Go 1.23, the current version of the linter is unhappy with the Go runtime sources, so let's update the linter, too!

Tested via https://github.com/arcalot/arcaflow-lib-kubernetes-go/pull/42.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).