### PR TITLE
Update golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64.5
+          version: v2.11.4
           args: --timeout=3m
   test:
     name: go test


### PR DESCRIPTION
## Summary
- Bump golangci-lint from v1.64.5 to v2.11.4
- Required for Go 1.25 support — v1.x was built with Go 1.24 and refuses to lint Go 1.25 targets

Repos using this workflow will need to migrate their `.golangci.yml` to v2 format:
- Add `version: "2"` at the top
- Move `gofmt` from `linters.enable` to `formatters.enable`
- Remove deprecated options (`check-shadowing`, `exportloopref`, `exclude-use-default`)

Part of an org-wide effort to update to Go 1.25.