### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/go_generate.yaml
+++ b/.github/workflows/go_generate.yaml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Run golangci-lint
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/go/pkg/mod
@@ -59,7 +59,7 @@ jobs:
           limgo -coverfile=/tmp/coverage.out -config=.limgo.json -outfmt=md -outfile=/tmp/coverage.md
           cat /tmp/coverage.md >> $GITHUB_STEP_SUMMARY
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results

--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: ${{ inputs.go_version }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
           args: --timeout=3m

--- a/.github/workflows/go_release.yaml
+++ b/.github/workflows/go_release.yaml
@@ -32,22 +32,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go_version }}
       - name: Login to the ${{ inputs.registry }} container registry
         if: env.do_login && startsWith(github.event.ref, 'refs/tags/')
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - name: Build ${{ inputs.for_release && 'release' || 'snapshot' }}
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         env:
           GITHUB_TOKEN: ${{ inputs.for_release && secrets.GITHUB_TOKEN || '' }}
           GOPROXY: direct
@@ -58,7 +58,7 @@ jobs:
           version: '~> v2'
           args: ${{ env.ARGS }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries
           path: dist

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -27,14 +27,14 @@ jobs:
           else echo "[ERR] wrong version format: $VERSION" ; exit 1
           fi
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: binaries
           path: python/artifacts
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
           architecture: 'x64'


### PR DESCRIPTION
## Summary
Bump all GitHub Actions to their latest major versions for Node.js 24 compatibility.

| Action | Old | New | Reason |
|--------|-----|-----|--------|
| `golangci/golangci-lint-action` | v6 | v7 | Required for golangci-lint v2 |
| `actions/checkout` | v4 | v6 | Node.js 24 |
| `actions/setup-go` | v5 | v6 | Node.js 24 |
| `actions/upload-artifact` | v4 | v7 | Node.js 24 |
| `actions/download-artifact` | v4 | v8 | Node.js 24 |
| `actions/cache` | v4 | v5 | Node.js 24 |
| `actions/setup-python` | v5 | v6 | Node.js 24 |
| `docker/login-action` | v3 | v4 | Node.js 24 |
| `goreleaser/goreleaser-action` | v6 | v7 | Node.js 24 |

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.