### PR TITLE
Update golangci-lint-action from v7 to v9 for Node.js 24

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: ${{ inputs.go_version }}
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4
           args: --timeout=3m


### PR DESCRIPTION
## Summary
- Bump `golangci/golangci-lint-action` from v7 to v9
- v9 switches from Node.js 20 to Node.js 24 runtime

### Remaining Node.js 20 warnings
These actions have no Node.js 24 versions available yet (upstream issue):
- `GoTestTools/gotestfmt-action@v2` — latest is v2.2.0, still Node.js 20
- `GoTestTools/limgo-action@v1.0.2` — latest is v1.0.2, still Node.js 20