### PR TITLE
Update limgo-action to v1.1.0 for Node.js 24

### DIFF
--- a/.github/workflows/go_lint_and_test.yaml
+++ b/.github/workflows/go_lint_and_test.yaml
@@ -43,7 +43,7 @@ jobs:
           key: go-test-${{ hashFiles('**/go.sum') }}
           restore-keys: go-test-
       - name: Set up limgo
-        uses: GoTestTools/limgo-action@v1.0.2
+        uses: GoTestTools/limgo-action@v1.1.0
         with:
           version: "v1.0.0"
           install-only: true


### PR DESCRIPTION
## Summary
- Bump `GoTestTools/limgo-action` from v1.0.2 to v1.1.0 (Node.js 24)
- `GoTestTools/gotestfmt-action@v2` already resolves to v2.3.0 (Node.js 24) via the floating tag

This eliminates the last Node.js 20 deprecation warning from the reusable workflows.